### PR TITLE
moved closed applications to archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Allstate](https://jobsearch.allstate.com/ShowJob/Id/1826200/Arity%20%20%20Software%20Engineer%20Intern)  | IL| Present | Rising juniors and seniors |
 | [Amazon](https://www.amazon.jobs/en/jobs/701508/software-development-engineer-internship-summer-2019-united-states)  | WA,  TX, CA, MA, CO, MI, VA, NY, WI, MN, AZ, OR | Present | Juniors and above only |
 | [Amazon Future Engineers](https://www.amazon.jobs/en/business_categories/university-recruiting)  | WA | Present  | For college freshmen and sophomores. 10 hours of cs-related community service required before application. |
-| [Arm](https://careers.peopleclick.com/careerscp/client_arm/external/jobDetails.do?functionName=getJobDetail&jobPostId=38844&localeCode=en-us) | TX | Present | |
 | [Asana](https://asana.com/jobs/university-recruiting)  | CA, NY | Present | | |
 | [Astranis](https://jobs.lever.co/astranis/?team=Internships)  | CA | Present | Fall 18, Spring 19, Summer 19. Software, but also Electrical, Aerospace, and Mechanical too! |
 | [Atlassian](https://www.atlassian.com/company/careers/detail/d4c1f25c-114d-4c97-8209-590393040664) | CA | Present
@@ -164,6 +163,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Altera | CA | |
 | American Express | AZ, FL, NY | |
 | Appian  | VA |  |
+| Arm | TX | Present | |
 | Asurion | CA |  |
 | Bank of America Freshman Summer Analyst | NC, AZ, NJ, FL, NY | Freshmen Only |
 | Blizzard | CA, TX (?) | |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Altera | CA | |
 | American Express | AZ, FL, NY | |
 | Appian  | VA |  |
-| Arm | TX | Present | |
+| Arm | TX | |
 | Asurion | CA |  |
 | Bank of America Freshman Summer Analyst | NC, AZ, NJ, FL, NY | Freshmen Only |
 | Blizzard | CA, TX (?) | |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Astranis](https://jobs.lever.co/astranis/?team=Internships)  | CA | Present | Fall 18, Spring 19, Summer 19. Software, but also Electrical, Aerospace, and Mechanical too! |
 | [Atlassian](https://www.atlassian.com/company/careers/detail/d4c1f25c-114d-4c97-8209-590393040664) | CA | Present
 | [BlackRock](https://www.wayup.com/i-Financial-Services-j-Software-Engineering-Summer-Analyst-2019-BlackRock-452850830832505/?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic)  | Multiple | Present | Juniors only |
-
 | [Boeing](https://jobs.boeing.com/job/seattle/engineering-internships-paid-summer-2019-multiple-locations/185/9103812)  | Multiple | Present | |
 | [Buzzfeed](https://boards.greenhouse.io/buzzfeed/jobs/1288982?gh_jid=1288982&gh_src=7fa4efd51) | NY, CA, MN | Present |  |
 | [Cisco](https://jobs.cisco.com/jobs/SearchJobs/?projectSort=schemaField_3_19_3&projectSortDirection=ASC&&projectOffset=0)  | Multiple | Present | Many opportunities, from [SWE](https://jobs.cisco.com/jobs/ProjectDetail/Software-Engineer-Bachelor-s-Intern-United-States/1231195?source=Cisco+Jobs+Career+Site&tags=CDC+SnNG+engineering-university-program) to [Data Science](https://jobs.cisco.com/jobs/ProjectDetail/Data-Scientist-Intern-United-States/1232432?source=Cisco+Jobs+Career+Site&tags=CDC+SnNG+engineering-university-program)—check main link for all listings |

--- a/README.md
+++ b/README.md
@@ -174,20 +174,20 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Cockroach Labs | NY | Backend engineering position |
 | Constant Contact | MA | Security research position |
 | Dow Jones | NJ | |
-| Dropbox | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
+| Dropbox | NY | |
 | Duolingo | PA | |
 | DRW | IL | |
 | Electronic Arts | TX | |
 | Enigma | NY | Seniors + juniors |
 | Facebook University| CA | For college freshmen and sophomores. Groups include engineering, operations, analytics, product design, and global marketing solutions.|
 | Fidelity| NC, RI, NH, TX | Software Engineer, Systems Analyst, Data Analyst, and Systems Engineer available |
-| Five Rings Capital  | NY | Present | |
+| Five Rings Capital  | NY | |
 | Honey | CA | |
 | HubSpot| MA | |
 | Hudl | MA | |
 | Hudson River Trading| NY | |
-| iCIMS | NJ | Present | |
-| Illumio | CA | Present | Must graduate in June 2020. Data Engineer role |
+| iCIMS | NJ | |
+| Illumio | CA | Must graduate in June 2020. Data Engineer role |
 | IMC Trading | IL | Present | |
 | Garmin | AZ, KS | Design Engineer, Software Engineer positions |
 | General Electric| FL, IL, MO, NV, PA, TX | |
@@ -196,7 +196,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Google Engineering Practicum | Multiple | For college freshmen and sophomores.|
 | Granular | IA | |
 | Groupon | IL, WA | |
-| Gusto  | CA | Present | |
+| Gusto  | CA | |
 | IBM | AZ, CA, CO, GA, MA, MN, NC, NY, OH, OR, PA, TX, VT | |
 | Indeed | Many | |
 | Intel | CA | |
@@ -209,7 +209,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Motorola| IL | No seniors |
 | Niantic | CA | |
 | Northrop Grumman  | MN | No seniors |
-| PayPal  | NY | Present ||
+| PayPal  | NY ||
 | Plexus | CO | Juniors preferred |
 | Reddit | CA | |
 | Riot Games | CA | |
@@ -218,7 +218,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Spotify | NY, MA | |
 | Synopsys | OR | Combines CS with EE |
 | Textron | MD | |
-| Twitch | CA | Present | Must have completed sophomore year |
+| Twitch | CA | Must have completed sophomore year |
 | Valassis| NC | Keywords: Big Data, High Scalability Engineering, Web Applications |
 | Verizon | Multiple | |
 | Yext | NY | |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [DE Shaw](https://www.deshaw.com/careers#internships)  | NY | Present | Many positions available: quant research, swe, etc. |
 | [Disney](https://jobs.disneycareers.com/search-jobs?k=intern)  | Multiple | Present | |
 | [Disney Animation](https://www.disneyanimation.com/careers/open-positions)  | CA | Present | |
-| [Dropbox](https://www.dropbox.com/jobs/listing/1244792?gh_src=aonhf1)  | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
 | [Ebay](https://jobs.ebayinc.com/job/bellevue/software-engineer-intern/403/9393469) | CA, WA, OR, MA, NY | Present | |
 | [Etsy](https://jobs.lever.co/etsy/20631f36-1825-4443-9f2a-51d5cfa5e4bb/apply?lever-source=themuse)  | NY | Present |  |
 | Facebook | CA, WA, CO | Present | Available positions: [Network Engineer](https://www.facebook.com/careers/jobs/a0I1H00000Mp4XXUAZ/), [Test Automation Engineer](https://www.facebook.com/careers/jobs/a0I1H00000Mp2bBUAR/)|
@@ -179,6 +178,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Cockroach Labs | NY | Backend engineering position |
 | Constant Contact | MA | Security research position |
 | Dow Jones | NJ | |
+| [Dropbox](https://www.dropbox.com/jobs/listing/1244792?gh_src=aonhf1)  | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
 | Duolingo | PA | |
 | DRW | IL | |
 | Electronic Arts | TX | |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Five Rings Capital](http://jobs.jobvite.com/fiverings/job/ouw77fwY)  | NY | Present | |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/emea/summer-analyst.html)  | NY | Present | For technical roles choose engineering |
 | [Google Summer of Code](https://summerofcode.withgoogle.com/organizations/)  | Remote | March 25 - April 9 | Organizations announced |
-| [Gusto](https://boards.greenhouse.io/gusto/jobs/483342)  | CA | Present | |
 | [HBO](https://careers.warnermediagroup.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&noback=0&partnerid=391&siteid=36&jobid=818472#jobDetails=818472_36) | WA | Present | |
 | [HCSS](hhttps://boards.greenhouse.io/hcss/jobs/1389685) | TX | Present | |
 | [HDE](https://www.hde.co.jp/en/gip/) | Tokyo | Present | |
@@ -198,6 +197,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Google Engineering Practicum | Multiple | For college freshmen and sophomores.|
 | Granular | IA | |
 | Groupon | IL, WA | |
+| Gusto  | CA | Present | |
 | IBM | AZ, CA, CO, GA, MA, MN, NC, NY, OH, OR, PA, TX, VT | |
 | Indeed | Many | |
 | Intel | CA | |

--- a/README.md
+++ b/README.md
@@ -23,18 +23,14 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Astranis](https://jobs.lever.co/astranis/?team=Internships)  | CA | Present | Fall 18, Spring 19, Summer 19. Software, but also Electrical, Aerospace, and Mechanical too! |
 | [Atlassian](https://www.atlassian.com/company/careers/detail/d4c1f25c-114d-4c97-8209-590393040664) | CA | Present
 | [BlackRock](https://www.wayup.com/i-Financial-Services-j-Software-Engineering-Summer-Analyst-2019-BlackRock-452850830832505/?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic)  | Multiple | Present | Juniors only |
-| [Blend](https://blend.com/careers/opening/university/?oid=2a469512-a8c2-44fa-a260-ef3ae0c90db7)  | CA | Present | Must graduate by June 2020 |
+
 | [Boeing](https://jobs.boeing.com/job/seattle/engineering-internships-paid-summer-2019-multiple-locations/185/9103812)  | Multiple | Present | |
 | [Buzzfeed](https://boards.greenhouse.io/buzzfeed/jobs/1288982?gh_jid=1288982&gh_src=7fa4efd51) | NY, CA, MN | Present |  |
-| [Cadre](https://cadre.com/careers/apply?gh_jid=1298465&gh_src=f4dnhe1)  | NY | Sep. 30 deadline | Graduate in Dec. 2019 or May 2020 |
-| [Chegg](https://jobs.chegg.com/job/CHEGA00561314/Software-Engineer-Intern)  | CA | Present | |
 | [Cisco](https://jobs.cisco.com/jobs/SearchJobs/?projectSort=schemaField_3_19_3&projectSortDirection=ASC&&projectOffset=0)  | Multiple | Present | Many opportunities, from [SWE](https://jobs.cisco.com/jobs/ProjectDetail/Software-Engineer-Bachelor-s-Intern-United-States/1231195?source=Cisco+Jobs+Career+Site&tags=CDC+SnNG+engineering-university-program) to [Data Science](https://jobs.cisco.com/jobs/ProjectDetail/Data-Scientist-Intern-United-States/1232432?source=Cisco+Jobs+Career+Site&tags=CDC+SnNG+engineering-university-program)—check main link for all listings |
 | [Clever](https://clever.com/about/jobs/detail?gh_jid=6194&gh_src=qnrd28) | CA | Present | |
 | [Coinbase](https://www.coinbase.com/careers)  | CA | Present | Available positions: [Machine Learning](https://www.coinbase.com/careers/919954), [Consumer Back End](https://www.coinbase.com/careers/919512), [Android dev](https://www.coinbase.com/careers/919969) |
 | [Convoy](https://jobs.lever.co/convoy/86c7bb6e-c592-43bf-87c8-a1eec90af2f3/apply?lever-source=Glassdoor)  | WA | Present | Must graduate in 2020 |
 | [Couple](https://couple.me/jobs)  | CA | Present | |
-| [Cox Automotive](https://www.recruit.net/job/software-engineer_north-hills_jobs/E637D0B356259D4E)  |  NY | Present | |
-| [Dell](https://jobs.dell.com/job/-/-/375/9080010)  | MA | Present | |
 | [DE Shaw](https://www.deshaw.com/careers#internships)  | NY | Present | Many positions available: quant research, swe, etc. |
 | [Disney](https://jobs.disneycareers.com/search-jobs?k=intern)  | Multiple | Present | |
 | [Disney Animation](https://www.disneyanimation.com/careers/open-positions)  | CA | Present | |
@@ -44,7 +40,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Flatiron Health](https://flatiron.com/careers/open-positions/)  | NY | Present | Must graduate between December 2019 and June 2020. Specific positions: [Software Engineer](https://flatiron.com/careers/open-positions/1244297), [Data Insights Engineer](https://flatiron.com/careers/open-positions/1264121), [Security Engineer](https://flatiron.com/careers/open-positions/1264168) |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/emea/summer-analyst.html)  | NY | Present | For technical roles choose engineering |
 | [Google Summer of Code](https://summerofcode.withgoogle.com/organizations/)  | Remote | March 25 - April 9 | Organizations announced |
-| [HBO](https://careers.warnermediagroup.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&noback=0&partnerid=391&siteid=36&jobid=818472#jobDetails=818472_36) | WA | Present | |
 | [HCSS](hhttps://boards.greenhouse.io/hcss/jobs/1389685) | TX | Present | |
 | [HDE](https://www.hde.co.jp/en/gip/) | Tokyo | Present | |
 | [Hulu](https://www.hulu.com/jobs/positions/oduj8fws) | CA, WA | Present | |
@@ -55,9 +50,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Jet.com](https://boards.greenhouse.io/embed/job_app?token=1259425)  | NJ | Present | |
 | [Jetbrains](https://www.jetbrains.com/company/jobs/)  | MA, Russia, Germany | Present | |
 | [JP Morgan](https://jpmchase.taleo.net/careersection/10140/jobdetail.ftl?job=180068843)  | NY, IL, OH, TX, NJ, DE, NY, TX, CA, FL, DE | Present | Must graduate by June 2020|
-| [Karat](https://jobs.lever.co/karat/c6666daf-6103-4430-85ac-4a45f5b0acfa)  | WA | Present | |
-| [Knewton](https://www.builtinnyc.com/job/internship/software-engineering-internship-summer-2019/42518)  | NY | Present | |
-| [Leidos](https://careers.leidos.com/jobs/3241160-software-developer-intern?tm_job=TR-659040&tm_event=view&tm_company=2502&bid=326)  | NJ | Present | Juniors and Seniors preferred |
 | [Lime](https://jobs.lever.co/limebike/f83ba173-769d-4992-88dc-ff828c87131d)  | CA | Present | |
 | [Lob](https://boards.greenhouse.io/lob/jobs/1389194)  | CA | Present | Must graduate in 2019 |
 | [Lockheed Martin](https://www.lockheedmartinjobs.com/search-jobs/intern/694/1?fl=6252001,4566966)  | Multiple | Present | |
@@ -77,12 +69,10 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [NetApp](https://jobs.netapp.com/go/University-Recruiting-Jobs/3583600/?q=&title=intern-+Software)  | CA, CO, KS, MA, NC, PA  | Present | |
 | [Nextdoor](https://nextdoor.com/jobs/?gh_jid=1258419)  | CA | Present | Must graduate in 2020 |
 | [New York Times](https://nytimes.wd5.myworkdayjobs.com/en-US/Intern-Biz)  | NY | Dec. 21 deadline (1st round), Jan 11/18 for round #2) | Additional internship opportunities for The New York Times: Software Engineering Intern - Ad Tech (Jan 11, 2019); Data Analytics Intern (Jan 18, 2019); Data Product Intern (Jan 18, 2019) |
-| [NFL](https://nfl.taleo.net/careersection/nfl_ex/jobdetail.ftl?job=1800005W&lang=en)  | NY | Present ||
 | [Nike](https://jobs.nike.com/job/beaverton/digital-undergraduate-intern/824/9277021)  | OR | Present | Expected graduation date of Winter 2019 or Spring 2020. Variety of positions available from Software Engineer to IOS Developer to Full Stack Developer. Reach out to [Melana Hammel '18](mailto:mhammel@alumni.princeton.edu) with any questions. |
 | [Noblis](https://jobs-noblis.icims.com/jobs/6218/2019-technical%2C-paid-summer-internships-%28returning%29/job)  | VA | Present | |
 | [Occipital](https://occipital.com/jobs)  | IL | Present | No official program, but open to internships for any full time engineering role |
 | [OpenAI](https://jobs.lever.co/openai/f9f7f8f3-90cc-41f3-a5b7-8692ab5da025)  | CA | Present | Summer Internship |
-| [Optiver](https://www.optiver.com/eu/en/job-opportunities/na-429)  | IL | Present | |
 | [OSIsoft](https://osisoft.wd1.myworkdayjobs.com/en-US/osisoft_careers/job/San-Leandro-California-USA/Software-Developer-Intern---Summer-2019_R001322)  | CA, TN, PA, AZ | Present | |
 | [Outreachy](https://www.outreachy.org/)  | Remote | February | Open source work with an organization of choice. For women (cis and trans), trans men, and genderqueer people, or people who are Black/African American, Hispanic/Latin@, Native American/American Indian, Alaska Native, Native Hawaiian, or Pacific Islander.  |
 | [Peloton](https://www.onepeloton.com/company/careers/857275)  | NY | Present | |
@@ -90,59 +80,42 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Plaid](https://plaid.com/careers/#software-engineer-intern)  | CA | Present | |
 | [Palantir](https://www.palantir.com/careers/)  | NY, CA, WA, D.C., Australia, London, Canada | Present | Must graduate in 2020|
 | [Palo Alto Networks](https://jobs.jobvite.com/paloaltonetworks/p/interns)  | CA, TX, VA, Netherlands, France | Present ||
-| [Pandora](http://jobs.jobvite.com/pandora/job/og0C8fwK)  | CA | Present | 2019/2020 grads only |
 | [Peak6 Investments](https://www.builtinchicago.org/job/internship/technology-experience-women-2019-summer-internship/64218)  | IL | Present | Must be female and graduate in Dec. 2019 or June 2020|
-| [Pinterest](https://careers.pinterest.com/careers/details/software-engineer-intern_san-francisco_1279340)  | CA | Present | |
 | [Platform.sh](https://platform.sh/company/careers/job?gh_jid=4100218002)  | Paris | Present ||
 | [Playstation](https://www.playstation.com/en-us/corporate/about/careers/internships/#joblistings)  | CA | Present | |
-| [Pure Storage](https://www.builtinseattle.com/job/internship/2019-software-engineer-intern-bel/3682)  | WA | Present |  |
 | [Qualcomm](https://jobs.qualcomm.com/public/jobDetails.xhtml?requisitionId=1966220)  | CA | Present | |
 | [Qualtrics](https://boards.greenhouse.io/qualtrics/jobs/755570?gh_src=91c3ce211)  | WA | Present | |
 | [Quantcast](https://jobs.lever.co/quantcast/1927c62b-837b-415e-8a13-32b720e90735)  | CA | Present | Graduation date between Dec. 2019 and June 2020 |
 | [Quora](https://www.quora.com/careers/university) | CA | Present | Available positions: [Data Scientist](https://jobs.lever.co/quora/2274c5e5-79de-47d3-bdf8-7a5bdfda0ebb?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic), [Product Designer](https://jobs.lever.co/quora/86333564-3855-4753-ba2f-6358115cb6af), [Machine Learning Intern(Only M.S. and Ph.D)](https://www.quora.com/careers/machine_learning_intern_2019), [Software Engineering Intern](https://www.quora.com/careers/software_engineer_intern_2019) |
-| [Raytheon](https://jobs.rayjobs.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25258&siteid=5368&AReq=120762BR&gqid=0&codes=3640#jobDetails=1402777_5368)  | MA | Present | |
-| [Red Ventures](https://www.careerbliss.com/jobs/detail/1603639395)  | NC | Present | Must graduate in 2020 |
 | [Reliance](https://careers.ril.com/students-and-graduates.aspx)  | Multiple | Present | 2+ years of experience |
 | [Roblox](https://corp.roblox.com/jobs/?gh_jid=1290141)  | CA | Present |  |
 | [Sabre](https://jobs.sabre.com/job/Southlake-Software-Developer-2019-Summer-Intern-TX-76092/511743500/?feedId=219200)  | TX | Present |  |
-| [Salesforce](https://salesforce.wd1.myworkdayjobs.com/en-US/External_Career_Site/job/California---San-Francisco/Summer-2019-Intern---Software-Engineer_JR20371)  | CA, NY, VA, FL, WA, GA, IN | Present |  |
 | [SAS Institute](https://careers-sas.icims.com/jobs/14937/technical-internship-summer-2019---software-development/job?hub=9)  | NC | Present | Also has special programs for veterans and minorities |
-| [Sensata](https://sensata.wd1.myworkdayjobs.com/en-US/Sensata-Careers/job/Bloomington-MN/Software-Engineer-2019-Summer-Intern_IRC73181)  | MN | Present |  |
 | [Servicenow](http://jobs.jobvite.com/careers/servicenow/jobs?c=Student%20-%20Internship)  | CA, WA | Present |  |
 |[Shopify](https://www.shopify.com/careers/interns) | Canada | Present | Groups include back-end and front-end web development, production engineering, data, UX research, design, sales, solutions engineering, business, finance, talent acquisition. |
 | [Slack](https://slack.com/careers/951251/summer-software-engineering-intern-2019)  | CA | Present |  |
 | [SpaceX](https://boards.greenhouse.io/spacex/jobs/4079311002?gh_jid=4079311002)  | FL, CA, TX, WA, D.C. | Present | |
 |[Spartez](https://spartez.com/jobs/back-end-developer-internship)  | Poland | Present | Backend |
-|[Starbucks](https://starbucks.taleo.net/careersection/1000222/jobdetail.ftl?job=180008367&lang=en&src=JB-12106) | WA | Present  | Dec 2019/June 2020 graduation date |
 | [Starsky Robotics](https://jobs.lever.co/starskyrobotics/636cbd7f-0a33-4072-996d-de28dc6b96ba)  | CA | Present |  |
 | [State Farm](https://statefarm.csod.com/ats/careersite/search.aspx?site=1&c=statefarm)  | IL | Present | For tech-specific: [link1](https://statefarm.csod.com/ats/careersite/JobDetails.aspx?site=1&id=4465) [link2](https://statefarm.csod.com/ats/careersite/JobDetails.aspx?site=1&id=4508) |
 | [Strava](https://boards.greenhouse.io/strava#.WFiiq6IrJBx)  | CA | Present | Rising Senior/New grad only |
 | [Stripe](https://stripe.com/jobs/positions/engineering-intern-san-francisco)  | CA | Present | Must graduate in 2020 or 2021.|
-| [Target](https://jobs.target.com/job/-/-/1118/8984961?src=JB-10182)  | MN | Present | Juniors only |
 | [Tenable](https://careers.tenable.com/jobs/software-engineering-intern-columbia-maryland-united-states)  | CO | Present |  |
-| [Teradata](https://careers.teradata.com/index.gp?method=cappportal.showJob&sysLayoutId=122&opportunityId=202560)  | CA | Present | |
 | [Tesla](https://www.tesla.com/careers/search#/?keyword=intern&department=1)  | CA | Present | |
-| [Thumbtack](https://boards.greenhouse.io/thumbtack/jobs/2570)  | CA | Present | Must graduate in 2020 |
 | [Tumblr](https://oath.wd5.myworkdayjobs.com/careers/job/US---New-York-Broadway-770/Tumblr-Engineering-Intern_JR0006522) | NY | Present | |
 | [Twilio](https://www.twilio.com/jobs)  | CA | Present | Multiple positions, including PM |
 | [Twitter](https://careers.twitter.com/en/work-for-twitter/201808/2019-university-application-full-time-internship.html)  | CA | Present | |
 | [Twitter Academy](https://twitteracademy19.splashthat.com/) | CA | Present | For second-year students who are black, Hispanic/Latinx, or Native American.|
-| [Two Sigma](https://careers.twosigma.com/careers/Careers?jobId=4252&source=Direct+Applicant&tags=internshipinfographic)  | NY | Present | [Quantitative Research](https://careers.twosigma.com/careers/Careers?jobId=4357&source=Direct+Applicant&tags=internshipinfographic) position also available.|
 | [Uber](https://www.uber.com/careers/list/41577/)  | CA | Present | |
 | [Under Armour](https://careers.underarmour.com/job/baltimore/rookie-2019-summer-league-internship-technology-and-product-development/7686/9059414)  | MD | Present | No freshmen |
 | [Unity](https://careers.unity.com/find-position?text=intern)  | Multiple | Present | Juniors/Seniors |
 | [UPS](https://www.jobs-ups.com/search-jobs/summer%20technology%20intern/1187/1)  | KY, MD, GA, NJ | Present |  |
-| [U.S. Bank](https://usbank.taleo.net/careersection/10000/jobdetail.ftl?job=180030905&iniurl.src=DM-10101&tz=GMT-04%3A00)  | MN | Present | |
-| [Visa](https://jobs.smartrecruiters.com/Visa/743999676973325-software-engineer-intern-bachelor-degree-multiple-locations)  | Multiple | Present |  |
 | [Vetcove](https://angel.co/vetcove/jobs/347448-software-engineering-intern-summer)  | NY | Present | Juniors Only |
-| [Vimeo](https://boards.greenhouse.io/vimeointernships/jobs/1412298?gh_src=b382173d1)  | NY | Present | 2019 or 2020 grads |
 | [Walmart](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25222&siteid=5022&jobid=1210863#jobDetails=1210863_5022)  | CA | Present | |
 | [WillowTree](https://willowtreeapps.com/careers#jobs)  | NC | Present | 2020 or 2021 graduates |
 | [Wish](https://jobs.lever.co/wish/edc42df8-fc30-47a9-ab93-5f0a185c4b0c)  | CA | Present | |
-| [Wolverine Trading](https://chk.tbe.taleo.net/chk01/ats/careers/requisition.jsp?org=WOLVE&cws=1&rid=280)  | IL | Present | |
 | [Xylem](https://www.xylem.com/en-us/careers/career-opportunities?page=1&pagesize=24&keyword=intern)  | OH | Present | Electrical Engineer Intern |
 | [Yahoo!](https://oath.wd5.myworkdayjobs.com/careers/job/US---Sunnyvale/Software-Engineering-Intern_JR0006043) | CA | Present | |
-| [Yelp](https://www.yelp.com/careers/job-openings/3f4cb3c8-4152-48b6-a76a-8226c2907400?description=Software-Engineer-Intern-Summer_College-Engineering-Product_San-Francisco-CA) | CA | Present | |
 | [Zendesk](https://www.zendesk.com/jobs/internships/) | Multiple locations | Present | Mostly for January - June 2019 |
 | [Zest Finance](https://www.themuse.com/jobs/zestfinance/software-engineer-internship-summer-2019)  | CA | Present |  |
 | [Zomato](https://zomato.recruitee.com)  | Multiple | Present | 2+ years of experience |
@@ -162,6 +135,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Bank of America Freshman Summer Analyst | NC, AZ, NJ, FL, NY | Freshmen Only |
 | Belvedere Trading | IL | Must graduate in Dec 2019/June 2020 |
 | Blackboard | AZ | Must have completed 3 years of core requirements |
+| [Blend](https://blend.com/careers/opening/university/?oid=2a469512-a8c2-44fa-a260-ef3ae0c90db7)  | CA | Must graduate by June 2020 |
 | Blizzard | CA, TX (?) | |
 | Bloomberg | NY | |
 | BookBub | MA | |
@@ -169,9 +143,13 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Bracebridge Capital | MA | |
 | Braze | NY | |
 | Broadway Technology  | NY | |
+| [Cadre](https://cadre.com/careers/apply?gh_jid=1298465&gh_src=f4dnhe1)  | NY | Graduate in Dec. 2019 or May 2020 |
+| [Chegg](https://jobs.chegg.com/job/CHEGA00561314/Software-Engineer-Intern)  | CA | |
 | Chick-fil-a | GA | Current juniors and seniors only |
 | Cockroach Labs | NY | Backend engineering position |
 | Constant Contact | MA | Security research position |
+| [Cox Automotive](https://www.recruit.net/job/software-engineer_north-hills_jobs/E637D0B356259D4E)  |  NY | |
+| [Dell](https://jobs.dell.com/job/-/-/375/9080010)  | MA | |
 | Dow Jones | NJ | |
 | Dropbox | NY | |
 | Duolingo | PA | |
@@ -181,6 +159,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Facebook University| CA | For college freshmen and sophomores. Groups include engineering, operations, analytics, product design, and global marketing solutions.|
 | Fidelity| NC, RI, NH, TX | Software Engineer, Systems Analyst, Data Analyst, and Systems Engineer available |
 | Five Rings Capital  | NY | |
+| [HBO](https://careers.warnermediagroup.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&noback=0&partnerid=391&siteid=36&jobid=818472#jobDetails=818472_36) | WA | |
 | Honey | CA | |
 | HubSpot| MA | |
 | Hudl | MA | |
@@ -202,24 +181,46 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | InterSystems | MA | |
 | Johnson & Johnson | NJ, FL, PA, IN, CA, RI, GA | |
 | Jump Trading | IL | |
+| [Karat](https://jobs.lever.co/karat/c6666daf-6103-4430-85ac-4a45f5b0acfa)  | WA | |
 | Kayak | MA | Data engineering position. SWE positions available in Germany and Lithuania|
 | Khan Academy | CA | |
+| [Knewton](https://www.builtinnyc.com/job/internship/software-engineering-internship-summer-2019/42518)  | NY | |
+| [Leidos](https://careers.leidos.com/jobs/3241160-software-developer-intern?tm_job=TR-659040&tm_event=view&tm_company=2502&bid=326)  | NJ | Juniors and Seniors preferred |
 | LinkedIn  | Multiple | No freshmen |
 | Morgan Stanley | NY | |
 | Motorola| IL | No seniors |
+| [NFL](https://nfl.taleo.net/careersection/nfl_ex/jobdetail.ftl?job=1800005W&lang=en)  | NY ||
 | Niantic | CA | |
 | Northrop Grumman  | MN | No seniors |
+| [Optiver](https://www.optiver.com/eu/en/job-opportunities/na-429)  | IL | |
+| [Pandora](http://jobs.jobvite.com/pandora/job/og0C8fwK)  | CA | 2019/2020 grads only |
 | PayPal  | NY ||
+| [Pinterest](https://careers.pinterest.com/careers/details/software-engineer-intern_san-francisco_1279340)  | CA | |
 | Plexus | CO | Juniors preferred |
+| [Pure Storage](https://www.builtinseattle.com/job/internship/2019-software-engineer-intern-bel/3682)  | WA |  |
+| [Raytheon](https://jobs.rayjobs.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25258&siteid=5368&AReq=120762BR&gqid=0&codes=3640#jobDetails=1402777_5368)  | MA | |
 | Reddit | CA | |
+| [Red Ventures](https://www.careerbliss.com/jobs/detail/1603639395)  | NC | Must graduate in 2020 |
 | Riot Games | CA | |
 | Robinhood | CA | |
+| [Salesforce](https://salesforce.wd1.myworkdayjobs.com/en-US/External_Career_Site/job/California---San-Francisco/Summer-2019-Intern---Software-Engineer_JR20371)  | CA, NY, VA, FL, WA, GA, IN |  |
+| [Sensata](https://sensata.wd1.myworkdayjobs.com/en-US/Sensata-Careers/job/Bloomington-MN/Software-Engineer-2019-Summer-Intern_IRC73181)  | MN |  |
 | Shutterfly | CA | |
 | Spotify | NY, MA | |
+|[Starbucks](https://starbucks.taleo.net/careersection/1000222/jobdetail.ftl?job=180008367&lang=en&src=JB-12106) | WA | Dec 2019/June 2020 graduation date |
 | Synopsys | OR | Combines CS with EE |
+| [Target](https://jobs.target.com/job/-/-/1118/8984961?src=JB-10182)  | MN | Juniors only |
+| [Teradata](https://careers.teradata.com/index.gp?method=cappportal.showJob&sysLayoutId=122&opportunityId=202560)  | CA | |
 | Textron | MD | |
+| [Thumbtack](https://boards.greenhouse.io/thumbtack/jobs/2570)  | CA | Must graduate in 2020 |
+| [Two Sigma](https://careers.twosigma.com/careers/Careers?jobId=4252&source=Direct+Applicant&tags=internshipinfographic)  | NY | [Quantitative Research](https://careers.twosigma.com/careers/Careers?jobId=4357&source=Direct+Applicant&tags=internshipinfographic) position also available.|
 | Twitch | CA | Must have completed sophomore year |
+| [U.S. Bank](https://usbank.taleo.net/careersection/10000/jobdetail.ftl?job=180030905&iniurl.src=DM-10101&tz=GMT-04%3A00)  | MN | |
+| [Vimeo](https://boards.greenhouse.io/vimeointernships/jobs/1412298?gh_src=b382173d1)  | NY | 2019 or 2020 grads |
+| [Visa](https://jobs.smartrecruiters.com/Visa/743999676973325-software-engineer-intern-bachelor-degree-multiple-locations)  | Multiple |  |
 | Valassis| NC | Keywords: Big Data, High Scalability Engineering, Web Applications |
 | Verizon | Multiple | |
+| [Wolverine Trading](https://chk.tbe.taleo.net/chk01/ats/careers/requisition.jsp?org=WOLVE&cws=1&rid=280)  | IL | |
+| [Yelp](https://www.yelp.com/careers/job-openings/3f4cb3c8-4152-48b6-a76a-8226c2907400?description=Software-Engineer-Intern-Summer_College-Engineering-Product_San-Francisco-CA) | CA | |
 | Yext | NY | |
 | Zynga| CA, Toronto | PM position also available. |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Name | Location | Application Period | Notes  |
 |---|---|---|---|
 | [Affirm](https://jobs.lever.co/affirm/ceb9ceef-cf1a-406d-b635-ba22470df7d6)  | CA | Present | |
-| [Airbnb](https://www.airbnb.com/careers/departments/position/1213896)  | CA | Present | |
 | [Akuna Capital](https://akunacapital.com/careers)  | IL, MA | Present | Graduation date by Spring 2020; diverse listings that range from C# to C++, Python, Web, Quant dev, etc. |
 | [Allstate](https://jobsearch.allstate.com/ShowJob/Id/1826200/Arity%20%20%20Software%20Engineer%20Intern)  | IL| Present | Rising juniors and seniors |
 | [Amazon](https://www.amazon.jobs/en/jobs/701508/software-development-engineer-internship-summer-2019-united-states)  | WA,  TX, CA, MA, CO, MI, VA, NY, WI, MN, AZ, OR | Present | Juniors and above only |
@@ -155,6 +154,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 ## Archived (applications closed)
 | Name | Location | Notes  |
 |---|---|---|
+| Airbnb | CA | |
 | AllianceBernstein | NY | |
 | Altera | CA | |
 | American Express | AZ, FL, NY | |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Thumbtack](https://boards.greenhouse.io/thumbtack/jobs/2570)  | CA | Present | Must graduate in 2020 |
 | [Tumblr](https://oath.wd5.myworkdayjobs.com/careers/job/US---New-York-Broadway-770/Tumblr-Engineering-Intern_JR0006522) | NY | Present | |
 | [Twilio](https://www.twilio.com/jobs)  | CA | Present | Multiple positions, including PM |
-| [Twitch](https://jobs.lever.co/twitch/564f4325-6bff-466e-8b4c-b20fde00ac2c) | CA | Present | Must have completed sophomore year |
 | [Twitter](https://careers.twitter.com/en/work-for-twitter/201808/2019-university-application-full-time-internship.html)  | CA | Present | |
 | [Twitter Academy](https://twitteracademy19.splashthat.com/) | CA | Present | For second-year students who are black, Hispanic/Latinx, or Native American.|
 | [Two Sigma](https://careers.twosigma.com/careers/Careers?jobId=4252&source=Direct+Applicant&tags=internshipinfographic)  | NY | Present | [Quantitative Research](https://careers.twosigma.com/careers/Careers?jobId=4357&source=Direct+Applicant&tags=internshipinfographic) position also available.|
@@ -219,6 +218,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Spotify | NY, MA | |
 | Synopsys | OR | Combines CS with EE |
 | Textron | MD | |
+| Twitch | CA | Present | Must have completed sophomore year |
 | Valassis| NC | Keywords: Big Data, High Scalability Engineering, Web Applications |
 | Verizon | Multiple | |
 | Yext | NY | |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Etsy](https://jobs.lever.co/etsy/20631f36-1825-4443-9f2a-51d5cfa5e4bb/apply?lever-source=themuse)  | NY | Present |  |
 | Facebook | CA, WA, CO | Present | Available positions: [Network Engineer](https://www.facebook.com/careers/jobs/a0I1H00000Mp4XXUAZ/), [Test Automation Engineer](https://www.facebook.com/careers/jobs/a0I1H00000Mp2bBUAR/)|
 | [Flatiron Health](https://flatiron.com/careers/open-positions/)  | NY | Present | Must graduate between December 2019 and June 2020. Specific positions: [Software Engineer](https://flatiron.com/careers/open-positions/1244297), [Data Insights Engineer](https://flatiron.com/careers/open-positions/1264121), [Security Engineer](https://flatiron.com/careers/open-positions/1264168) |
-| [Five Rings Capital](http://jobs.jobvite.com/fiverings/job/ouw77fwY)  | NY | Present | |
 | [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/emea/summer-analyst.html)  | NY | Present | For technical roles choose engineering |
 | [Google Summer of Code](https://summerofcode.withgoogle.com/organizations/)  | Remote | March 25 - April 9 | Organizations announced |
 | [HBO](https://careers.warnermediagroup.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&noback=0&partnerid=391&siteid=36&jobid=818472#jobDetails=818472_36) | WA | Present | |
@@ -182,6 +181,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Enigma | NY | Seniors + juniors |
 | Facebook University| CA | For college freshmen and sophomores. Groups include engineering, operations, analytics, product design, and global marketing solutions.|
 | Fidelity| NC, RI, NH, TX | Software Engineer, Systems Analyst, Data Analyst, and Systems Engineer available |
+| Five Rings Capital  | NY | Present | |
 | Honey | CA | |
 | HubSpot| MA | |
 | Hudl | MA | |

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Asana](https://asana.com/jobs/university-recruiting)  | CA, NY | Present | | |
 | [Astranis](https://jobs.lever.co/astranis/?team=Internships)  | CA | Present | Fall 18, Spring 19, Summer 19. Software, but also Electrical, Aerospace, and Mechanical too! |
 | [Atlassian](https://www.atlassian.com/company/careers/detail/d4c1f25c-114d-4c97-8209-590393040664) | CA | Present
-| [Belvedere Trading](http://belvederetrading.applicantstack.com/x/detail/a2sa4x0n04ox)  | IL | Present | Must graduate in Dec 2019/June 2020 |
-| [Blackboard](https://careers.blackboard.com/careers/position/software-engineer-intern-phoenix-az-usa-2) | AZ | Present | Must have completed 3 years of core requirements |
 | [BlackRock](https://www.wayup.com/i-Financial-Services-j-Software-Engineering-Summer-Analyst-2019-BlackRock-452850830832505/?utm_campaign=google_jobs_apply&utm_source=google_jobs_apply&utm_medium=organic)  | Multiple | Present | Juniors only |
 | [Blend](https://blend.com/careers/opening/university/?oid=2a469512-a8c2-44fa-a260-ef3ae0c90db7)  | CA | Present | Must graduate by June 2020 |
 | [Boeing](https://jobs.boeing.com/job/seattle/engineering-internships-paid-summer-2019-multiple-locations/185/9103812)  | Multiple | Present | |
@@ -162,6 +160,8 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Arm | TX | |
 | Asurion | CA |  |
 | Bank of America Freshman Summer Analyst | NC, AZ, NJ, FL, NY | Freshmen Only |
+| Belvedere Trading | IL | Must graduate in Dec 2019/June 2020 |
+| Blackboard | AZ | Must have completed 3 years of core requirements |
 | Blizzard | CA, TX (?) | |
 | Bloomberg | NY | |
 | BookBub | MA | |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Cockroach Labs | NY | Backend engineering position |
 | Constant Contact | MA | Security research position |
 | Dow Jones | NJ | |
-| [Dropbox](https://www.dropbox.com/jobs/listing/1244792?gh_src=aonhf1)  | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
+| [Dropbox] | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
 | Duolingo | PA | |
 | DRW | IL | |
 | Electronic Arts | TX | |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Jetbrains](https://www.jetbrains.com/company/jobs/)  | MA, Russia, Germany | Present | |
 | [JP Morgan](https://jpmchase.taleo.net/careersection/10140/jobdetail.ftl?job=180068843)  | NY, IL, OH, TX, NJ, DE, NY, TX, CA, FL, DE | Present | Must graduate by June 2020|
 | [Karat](https://jobs.lever.co/karat/c6666daf-6103-4430-85ac-4a45f5b0acfa)  | WA | Present | |
-| [Khan Academy](https://boards.greenhouse.io/khanacademy/jobs/15827)  | CA | Present | |
 | [Knewton](https://www.builtinnyc.com/job/internship/software-engineering-internship-summer-2019/42518)  | NY | Present | |
 | [Leidos](https://careers.leidos.com/jobs/3241160-software-developer-intern?tm_job=TR-659040&tm_event=view&tm_company=2502&bid=326)  | NJ | Present | Juniors and Seniors preferred |
 | [Lime](https://jobs.lever.co/limebike/f83ba173-769d-4992-88dc-ff828c87131d)  | CA | Present | |
@@ -204,6 +203,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Johnson & Johnson | NJ, FL, PA, IN, CA, RI, GA | |
 | Jump Trading | IL | |
 | Kayak | MA | Data engineering position. SWE positions available in Germany and Lithuania|
+| Khan Academy | CA | |
 | LinkedIn  | Multiple | No freshmen |
 | Morgan Stanley | NY | |
 | Motorola| IL | No seniors |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | [Palantir](https://www.palantir.com/careers/)  | NY, CA, WA, D.C., Australia, London, Canada | Present | Must graduate in 2020|
 | [Palo Alto Networks](https://jobs.jobvite.com/paloaltonetworks/p/interns)  | CA, TX, VA, Netherlands, France | Present ||
 | [Pandora](http://jobs.jobvite.com/pandora/job/og0C8fwK)  | CA | Present | 2019/2020 grads only |
-| [PayPal](https://jobsearch.paypal-corp.com/en-US/job/-/J3T6VC67NC757TJ3Z30)  | NY | Present ||
 | [Peak6 Investments](https://www.builtinchicago.org/job/internship/technology-experience-women-2019-summer-internship/64218)  | IL | Present | Must be female and graduate in Dec. 2019 or June 2020|
 | [Pinterest](https://careers.pinterest.com/careers/details/software-engineer-intern_san-francisco_1279340)  | CA | Present | |
 | [Platform.sh](https://platform.sh/company/careers/job?gh_jid=4100218002)  | Paris | Present ||
@@ -211,6 +210,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Motorola| IL | No seniors |
 | Niantic | CA | |
 | Northrop Grumman  | MN | No seniors |
+| [PayPal]  | NY | Present ||
 | Plexus | CO | Juniors preferred |
 | Reddit | CA | |
 | Riot Games | CA | |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Cockroach Labs | NY | Backend engineering position |
 | Constant Contact | MA | Security research position |
 | Dow Jones | NJ | |
-| [Dropbox] | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
+| Dropbox | NY | Present | Must graduate in/after December 2019. [Seattle application](https://www.builtinseattle.com/job/internship/software-engineer-intern-summer-2019/3596) |
 | Duolingo | PA | |
 | DRW | IL | |
 | Electronic Arts | TX | |
@@ -210,7 +210,7 @@ Two-letter locations indicate states in the U.S.; countries other than the U.S. 
 | Motorola| IL | No seniors |
 | Niantic | CA | |
 | Northrop Grumman  | MN | No seniors |
-| [PayPal]  | NY | Present ||
+| PayPal  | NY | Present ||
 | Plexus | CO | Juniors preferred |
 | Reddit | CA | |
 | Riot Games | CA | |


### PR DESCRIPTION
Leaved the hyperlink in archived for rechecking.
list of moved programs:
blend
cadre
chegg
cox automotive
dell
hbo
karat
kewton
leidos
nfl
optiver
pandora
pinterest
purestorage
raytheon
red ventures
salesforce
sensata
starbucks
target
teradata.
thumbtack
two sigma
us bank
visa
vimeo
wolverine trading
yelp
zynga